### PR TITLE
Add grocery list feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -544,6 +544,29 @@ def create_calendar_layout():
     )
 
 
+def create_grocery_layout():
+    return html.Div(
+        [
+            dbc.Card(
+                [
+                    dbc.CardHeader(t("Grocery List")),
+                    dbc.CardBody(
+                        [
+                            dbc.Button(
+                                t("Refresh"),
+                                id="refresh-grocery-btn",
+                                color="secondary",
+                                className="mb-3",
+                            ),
+                            html.Div(id="grocery-table"),
+                        ]
+                    ),
+                ]
+            )
+        ]
+    )
+
+
 def create_pantry_layout():
     return html.Div(
         [
@@ -706,6 +729,7 @@ def build_layout(lang: str) -> dbc.Container:
                     ),
                     dbc.Tab(create_recipe_layout(), label=t("Recipes"), tab_id="recipes"),
                     dbc.Tab(create_calendar_layout(), label=t("Meal Calendar"), tab_id="calendar"),
+                    dbc.Tab(create_grocery_layout(), label=t("Grocery List"), tab_id="grocery"),
                     dbc.Tab(
                         create_preferences_layout(), label=t("Preferences"), tab_id="preferences"
                     ),
@@ -1289,6 +1313,24 @@ def update_pantry_contents(_n_clicks, _add_message):
 )
 def update_transaction_history(_n_clicks, _add_message):
     return pantry.get_transaction_history()
+
+
+@app.callback(Output("grocery-table", "children"), Input("refresh-grocery-btn", "n_clicks"))
+def update_grocery_list(_n_clicks):
+    items = pantry.get_grocery_list()
+    if not items:
+        return html.P("No items needed")
+
+    return dash_table.DataTable(
+        data=items,
+        columns=[
+            {"name": "Item", "id": "name"},
+            {"name": "Quantity", "id": "quantity"},
+            {"name": "Unit", "id": "unit"},
+        ],
+        style_cell={"textAlign": "left"},
+        style_header={"backgroundColor": "rgb(230, 230, 230)", "fontWeight": "bold"},
+    )
 
 
 if __name__ == "__main__":

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -244,6 +244,13 @@ def get_week_plan() -> Dict[str, Any]:
     return {"status": "success", "plan": plan}
 
 
+@mcp.tool()
+def get_grocery_list() -> Dict[str, Any]:
+    """Return grocery items needed for the coming week's meal plan."""
+    items = pantry.get_grocery_list()
+    return {"status": "success", "grocery": items}
+
+
 # Entry point to run the server
 if __name__ == "__main__":
     mcp.run()

--- a/tests/test_pantry_manager.py
+++ b/tests/test_pantry_manager.py
@@ -353,6 +353,30 @@ class TestPantryManager(unittest.TestCase):
         retrieved = self.pantry.get_meal_plan(start, end)
         self.assertEqual(plan, retrieved)
 
+    def test_grocery_list(self):
+        """Test calculating grocery list based on meal plan and pantry contents."""
+        recipe = {
+            "name": "Toast",
+            "instructions": "Toast bread",
+            "time_minutes": 5,
+            "ingredients": [
+                {"name": "bread", "quantity": 2, "unit": "slices"},
+                {"name": "butter", "quantity": 1, "unit": "tbsp"},
+            ],
+        }
+        self.pantry.add_recipe(**recipe)
+        self.pantry.set_meal_plan(date.today().isoformat(), "Toast")
+
+        # Only one slice of bread in pantry, enough butter
+        self.pantry.add_item("bread", 1, "slices")
+        self.pantry.add_item("butter", 2, "tbsp")
+
+        grocery = self.pantry.get_grocery_list()
+        self.assertEqual(len(grocery), 1)
+        self.assertEqual(grocery[0]["name"], "bread")
+        self.assertEqual(grocery[0]["unit"], "slices")
+        self.assertEqual(grocery[0]["quantity"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- compute grocery list from upcoming meal plan
- expose new MCP tool `get_grocery_list`
- add Grocery List tab in Dash app
- display grocery list via callback
- test grocery list generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68871550311c8330a80df922ddc353a2