### PR TITLE
Generate short IDs in database

### DIFF
--- a/db_schema_definitions.py
+++ b/db_schema_definitions.py
@@ -27,7 +27,9 @@ SINGLE_USER_SCHEMAS = {
     "recipes": """
         CREATE TABLE IF NOT EXISTS Recipes (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            short_id TEXT NOT NULL UNIQUE,
+            short_id TEXT GENERATED ALWAYS AS (
+                'R' || hex(id) || substr('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ', (id % 36) + 1, 1)
+            ) STORED UNIQUE,
             name TEXT NOT NULL,
             instructions TEXT NOT NULL,
             time_minutes INTEGER NOT NULL,
@@ -127,7 +129,9 @@ MULTI_USER_POSTGRESQL_SCHEMAS = {
     "recipes": """
         CREATE TABLE IF NOT EXISTS recipes (
             id SERIAL PRIMARY KEY,
-            short_id VARCHAR(10) NOT NULL,
+            short_id TEXT GENERATED ALWAYS AS (
+                'R' || upper(to_hex(id)) || substr('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ', (id % 36) + 1, 1)
+            ) STORED,
             user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
             name VARCHAR(255) NOT NULL,
             instructions TEXT NOT NULL,
@@ -209,7 +213,9 @@ MULTI_USER_SQLITE_SCHEMAS = {
     "recipes": """
         CREATE TABLE IF NOT EXISTS recipes (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            short_id TEXT NOT NULL,
+            short_id TEXT GENERATED ALWAYS AS (
+                'R' || hex(id) || substr('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ', (id % 36) + 1, 1)
+            ) STORED,
             user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
             name TEXT NOT NULL,
             instructions TEXT NOT NULL,

--- a/pantry_manager_abc.py
+++ b/pantry_manager_abc.py
@@ -299,7 +299,7 @@ class PantryManager(ABC):
         Get a recipe and its ingredients by short ID.
 
         Args:
-            short_id: Short ID of the recipe (e.g., "R123A")
+            short_id: Short ID of the recipe (e.g., "R1F")
 
         Returns:
             Optional[Dict[str, Any]]: Recipe details including ingredients, or None if not found
@@ -332,7 +332,7 @@ class PantryManager(ABC):
         Edit an existing recipe by short ID with detailed error messages.
 
         Args:
-            short_id: Short ID of the recipe to edit (e.g., "R123A")
+            short_id: Short ID of the recipe to edit (e.g., "R1F")
             name: New name for the recipe (optional)
             instructions: Updated cooking instructions (optional)
             time_minutes: Updated time required (optional)

--- a/short_id_utils.py
+++ b/short_id_utils.py
@@ -1,117 +1,56 @@
 #!/usr/bin/env python3
-"""
-Short ID utilities for recipe management.
-Generates human-friendly short IDs with checksums to prevent confusion.
+"""Short ID utilities for recipe management.
 
-Format: R{number}{checksum}
-Example: R123X, R456M, R789Q
+Short IDs are generated from the numeric primary key as an uppercase
+hexadecimal string prefixed with ``R`` and suffixed with a single checksum
+character.  The checksum is a base36 character derived from the numeric id.
 
-- R prefix indicates it's a recipe ID
-- Base 36 encoding for compact representation
-- Single checksum character to catch typos
-- Maximum ~46k unique IDs (R1A - RZZZ)
+For example, database ID ``15`` becomes ``RFF`` and ``255`` becomes ``RFF3``.
 """
 
-import string
-import hashlib
+import re
 from typing import Optional
-from error_utils import validate_required_params
 
-# Constants
-ALPHABET = string.digits + string.ascii_uppercase
 PREFIX = "R"
+ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+ID_RE = re.compile(r"^R[0-9A-F]+[0-9A-Z]$")
+
+
+def _checksum(numeric_id: int) -> str:
+    """Return the checksum character for the given numeric id."""
+    return ALPHABET[numeric_id % 36]
 
 
 def generate_short_id(numeric_id: int) -> str:
-    """
-    Generate a short ID from a numeric database ID.
-
-    Args:
-        numeric_id: The database ID (integer)
-
-    Returns:
-        str: Short ID in format R{base36}{checksum}
-
-    Example:
-        generate_short_id(123) -> "R3FX"
-        generate_short_id(1000) -> "RRSM"
-
-    Raises:
-        ValueError: If numeric_id is not positive
-    """
+    """Generate a short ID from a numeric database ID using hex encoding."""
     if numeric_id <= 0:
         raise ValueError("Numeric ID must be positive")
-
-    # Convert to base36 using Python's built-in functions
-    base36 = _to_base36(numeric_id)
-
-    # Generate checksum
-    checksum = _calculate_checksum(base36)
-
-    return f"{PREFIX}{base36}{checksum}"
+    body = f"{numeric_id:X}"
+    return f"{PREFIX}{body}{_checksum(numeric_id)}"
 
 
 def parse_short_id(short_id: str) -> Optional[int]:
-    """
-    Parse a short ID back to the original numeric ID.
-
-    Args:
-        short_id: Short ID string (e.g., "R3FX")
-
-    Returns:
-        Optional[int]: Original numeric ID if valid, None if invalid
-    """
+    """Parse a short ID back to the original numeric ID."""
     if not short_id or not isinstance(short_id, str):
         return None
 
-    short_id = short_id.upper().strip()
-
-    # Check format
-    if not short_id.startswith(PREFIX) or len(short_id) < 3:
+    short_id = short_id.strip().upper()
+    if not ID_RE.fullmatch(short_id):
         return None
 
-    # Extract parts
-    body = short_id[1:-1]  # Remove prefix and checksum
-    provided_checksum = short_id[-1]
-
-    # Validate checksum
-    expected_checksum = _calculate_checksum(body)
-    if provided_checksum != expected_checksum:
-        return None
-
+    body = short_id[1:-1]
+    checksum = short_id[-1]
     try:
-        # Convert back to decimal using built-in int()
-        return int(body, 36)
+        numeric_id = int(body, 16)
     except ValueError:
         return None
+
+    if _checksum(numeric_id) != checksum:
+        return None
+
+    return numeric_id
 
 
 def is_valid_short_id(short_id: str) -> bool:
     """Check if a short ID is valid."""
     return parse_short_id(short_id) is not None
-
-
-def _to_base36(num: int) -> str:
-    """Convert integer to base36 string using built-in functions."""
-    if num == 0:
-        return "0"
-
-    # Use numpy.base_repr equivalent logic but simpler
-    digits = []
-    while num:
-        num, remainder = divmod(num, 36)
-        digits.append(ALPHABET[remainder])
-    return "".join(reversed(digits))
-
-
-def _calculate_checksum(data: str) -> str:
-    """Calculate single-character checksum from data."""
-    # Use MD5 hash and map to our alphabet
-    hash_obj = hashlib.md5(data.encode("utf-8"))
-    hex_digest = hash_obj.hexdigest()
-
-    # Take first hex character and map to base36 alphabet
-    hex_char = hex_digest[0].upper()
-
-    # Map 0-9 directly, A-F to A-F (both are in our alphabet)
-    return hex_char if hex_char in ALPHABET else "0"


### PR DESCRIPTION
## Summary
- compute recipe short IDs in SQL using hex of the autoincrement id and a base36 checksum
- fetch new ids using RETURNING clauses and drop client-side prediction logic
- simplify short id utilities and update migration script and tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'psycopg2')*
- `pytest tests/test_short_id_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6898b8e034c08330943c2bcfd1486787