### PR TITLE
Support unit conversions when checking pantry availability

### DIFF
--- a/app_flask.py
+++ b/app_flask.py
@@ -480,7 +480,7 @@ def view_recipe(recipe_name):
 
     for ingredient in recipe["ingredients"]:
         needed_quantity = ingredient["quantity"]
-        available_quantity = user_pantry.get_item_quantity(
+        available_quantity = user_pantry.get_total_item_quantity(
             ingredient["name"], ingredient["unit"]
         )
 

--- a/pantry_manager_abc.py
+++ b/pantry_manager_abc.py
@@ -178,6 +178,11 @@ class PantryManager(ABC):
         pass
 
     @abstractmethod
+    def get_total_item_quantity(self, item_name: str, unit: str) -> float:
+        """Get total quantity of an item across all units converted to the specified unit."""
+        pass
+
+    @abstractmethod
     def get_pantry_contents(self) -> Dict[str, Dict[str, float]]:
         """
         Get the current contents of the pantry.

--- a/pantry_manager_shared.py
+++ b/pantry_manager_shared.py
@@ -616,6 +616,48 @@ class SharedPantryManager(PantryManager):
             print(f"Error getting item quantity: {e}")
             return 0.0
 
+    def get_total_item_quantity(self, item_name: str, unit: str) -> float:
+        """Get total quantity of an item across all units converted to the specified unit for the current user."""
+        try:
+            with self._get_connection() as conn:
+                cursor = conn.cursor()
+                ph = self._get_placeholder()
+
+                ingredient_id = self.get_ingredient_id(item_name)
+                if ingredient_id is None:
+                    return 0.0
+
+                cursor.execute(
+                    f"SELECT base_unit, size FROM units WHERE user_id = {ph} AND name = {ph}",
+                    (self.user_id, unit),
+                )
+                target = cursor.fetchone()
+                if not target:
+                    return self.get_item_quantity(item_name, unit)
+                target_base, target_size = target
+
+                cursor.execute(
+                    f"""
+                    SELECT t.unit, u.base_unit, u.size,
+                           SUM(CASE WHEN t.transaction_type = 'addition' THEN t.quantity ELSE -t.quantity END) AS net_quantity
+                    FROM pantry_transactions t
+                    JOIN units u ON t.unit = u.name AND u.user_id = t.user_id
+                    WHERE t.user_id = {ph} AND t.ingredient_id = {ph}
+                    GROUP BY t.unit, u.base_unit, u.size
+                    """,
+                    (self.user_id, ingredient_id),
+                )
+
+                total_base = 0.0
+                for unit_name, base_unit, size, qty in cursor.fetchall():
+                    if base_unit == target_base and qty:
+                        total_base += qty * size
+
+                return total_base / target_size
+        except Exception as e:
+            print(f"Error getting total item quantity: {e}")
+            return 0.0
+
     def get_multiple_item_quantities(
         self, items: List[tuple[str, str]]
     ) -> Dict[tuple[str, str], float]:
@@ -1239,7 +1281,7 @@ class SharedPantryManager(PantryManager):
             missing_ingredients = []
             for ingredient in recipe["ingredients"]:
                 needed_quantity = ingredient["quantity"]
-                available_quantity = self.get_item_quantity(
+                available_quantity = self.get_total_item_quantity(
                     ingredient["name"], ingredient["unit"]
                 )
 

--- a/tests/test_pantry_manager.py
+++ b/tests/test_pantry_manager.py
@@ -128,6 +128,16 @@ class TestPantryManager(unittest.TestCase):
         self.assertIsNotNone(pot)
         self.assertEqual(pot["size"], 350)
 
+    def test_total_item_quantity_conversion(self):
+        """Quantities should be converted across units with the same base unit."""
+        self.pantry.set_unit("Pot of honey", "ml", 350)
+        self.pantry.add_item("honey", 1, "Pot of honey")
+
+        qty_tbsp = self.pantry.get_total_item_quantity("honey", "Tablespoon")
+        self.assertAlmostEqual(qty_tbsp, 350 / 15, places=2)
+        qty_ml = self.pantry.get_total_item_quantity("honey", "Milliliter")
+        self.assertAlmostEqual(qty_ml, 350, places=2)
+
     def test_add_ingredient(self):
         """Test adding a new ingredient"""
         success = self.pantry.add_ingredient("flour", "g")


### PR DESCRIPTION
## Summary
- add `get_total_item_quantity` to pantry managers to convert and sum ingredient quantities across compatible units
- use the new conversion-aware quantity check when rendering recipe grocery overview and when executing recipes
- test custom unit conversions like "Pot of honey" to tablespoons and milliliters

## Testing
- `pytest tests/test_pantry_manager.py tests/test_mcp_tool_routing.py tests/mcp_tests/test_scenarios.py -q`
- ⚠️ `pytest` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6898ddbfe2c08330aed29b2c53b79a84