### PR TITLE
Enable household invites with shared secrets

### DIFF
--- a/db_schema_definitions.py
+++ b/db_schema_definitions.py
@@ -101,6 +101,15 @@ MULTI_USER_POSTGRESQL_SCHEMAS = {
             household_children INTEGER DEFAULT 0
         )
     """,
+    "household_invites": """
+        CREATE TABLE IF NOT EXISTS household_invites (
+            id SERIAL PRIMARY KEY,
+            owner_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+            email VARCHAR(120) NOT NULL,
+            secret VARCHAR(128) NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """,
     "units": """
         CREATE TABLE IF NOT EXISTS units (
             id SERIAL PRIMARY KEY,
@@ -197,6 +206,15 @@ MULTI_USER_SQLITE_SCHEMAS = {
             household_children INTEGER DEFAULT 0
         )
     """,
+    "household_invites": """
+        CREATE TABLE IF NOT EXISTS household_invites (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            owner_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+            email TEXT NOT NULL,
+            secret TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """,
     "units": """
         CREATE TABLE IF NOT EXISTS units (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -289,6 +307,8 @@ MULTI_USER_POSTGRESQL_INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_pantry_transactions_ingredient_unit ON pantry_transactions(user_id, ingredient_id, unit)",
     "CREATE INDEX IF NOT EXISTS idx_recipe_ingredients_recipe_id ON recipe_ingredients(recipe_id)",
     "CREATE INDEX IF NOT EXISTS idx_meal_plan_user_date ON meal_plan(user_id, meal_date)",
+    "CREATE INDEX IF NOT EXISTS idx_household_invites_secret ON household_invites(secret)",
+    "CREATE INDEX IF NOT EXISTS idx_household_invites_owner_id ON household_invites(owner_id)",
 ]
 
 MULTI_USER_SQLITE_INDEXES = (

--- a/templates/auth/invite.html
+++ b/templates/auth/invite.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Invite - Meal Manager</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-6 col-lg-5">
+                <div class="card shadow-sm mt-5">
+                    <div class="card-header text-center bg-success text-white">
+                        <h4 class="mb-0">
+                            <i class="fas fa-envelope"></i> {{ t('Send Household Invite') }}
+                        </h4>
+                    </div>
+                    <div class="card-body">
+                        {% with messages = get_flashed_messages(with_categories=true) %}
+                            {% if messages %}
+                                {% for category, message in messages %}
+                                    <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
+                                        {{ message }}
+                                        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                                    </div>
+                                {% endfor %}
+                            {% endif %}
+                        {% endwith %}
+                        <form method="POST">
+                            <div class="mb-3">
+                                <label for="email" class="form-label">
+                                    <i class="fas fa-envelope"></i> {{ t('Email Address') }}
+                                </label>
+                                <input type="email" class="form-control" id="email" name="email" required placeholder="{{ t('Enter invitee email') }}">
+                            </div>
+                            <div class="d-grid">
+                                <button type="submit" class="btn btn-success">
+                                    {{ t('Send Invite') }}
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                    <div class="card-footer text-center">
+                        <a href="{{ url_for('profile') }}" class="text-decoration-none">{{ t('Back to Profile') }}</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/templates/auth/register.html
+++ b/templates/auth/register.html
@@ -78,12 +78,13 @@
                             </div>
 
                             <div class="mb-3">
-                                <label for="household_username" class="form-label">
-                                    <i class="fas fa-home"></i> {{ t('Household Username (optional)') }}
+                                <label for="invite_code" class="form-label">
+                                    <i class="fas fa-key"></i> {{ t('Invite Code (optional)') }}
                                 </label>
-                                <input type="text" class="form-control" id="household_username" name="household_username"
-                                       placeholder="{{ t('Enter existing household username') }}">
-                                <small class="form-text text-muted">{{ t('Leave blank to create a new household') }}</small>
+                                <input type="text" class="form-control" id="invite_code" name="invite_code"
+                                       value="{{ invite_code }}"
+                                       placeholder="{{ t('Enter your invite code') }}">
+                                <small class="form-text text-muted">{{ t('Leave blank to start a new household') }}</small>
                             </div>
 
                             <div class="d-grid">


### PR DESCRIPTION
## Summary
- allow registration page to prefill invite codes passed in the URL
- send invitation emails with direct registration links containing secret tokens
- keep invite codes populated in the registration form after validation errors

## Testing
- `pip install psycopg2-binary` *(fails: Could not find a version that satisfies the requirement psycopg2-binary)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_6898f20d4158833089530b4d1a6988ef