### PR TITLE
Use PANTRY_DATABASE_URL for shared DB setup and log failing queries

### DIFF
--- a/db_setup_shared.py
+++ b/db_setup_shared.py
@@ -3,9 +3,10 @@ Database setup for single-database multi-user approach.
 All users share one database with user_id scoping.
 """
 
+import os
 import sqlite3
 import psycopg2
-from typing import Union
+from typing import Iterable, Union, Type
 from db_schema_definitions import (
     MULTI_USER_POSTGRESQL_SCHEMAS,
     MULTI_USER_SQLITE_SCHEMAS,
@@ -16,17 +17,37 @@ from db_schema_definitions import (
 from error_utils import safe_execute
 
 
-def setup_shared_database(connection: Union[str, object]) -> bool:
-    """
-    Set up database schema for single-database multi-user mode.
+def _execute_with_reporting(
+    cursor, sql: str, ignore_exceptions: Iterable[Type[BaseException]] = ()
+) -> None:
+    """Execute a SQL statement and report failures with the offending query."""
+    try:
+        cursor.execute(sql)
+    except tuple(ignore_exceptions):
+        pass
+    except Exception as e:
+        print(f"Error executing query: {e}\nQuery:\n{sql}")
+        raise
+
+
+def setup_shared_database(connection: Union[str, object, None] = None) -> bool:
+    """Set up database schema for single-database multi-user mode.
 
     Args:
-        connection: Either a connection string (for PostgreSQL) or connection object
+        connection: Optional connection string. If not provided, the
+            PANTRY_DATABASE_URL environment variable will be used. For PostgreSQL
+            the value must start with ``postgresql://`` or ``postgres://``. Any
+            other string is treated as a SQLite path.
 
     Returns:
         bool: True if successful, False otherwise
     """
     try:
+        if connection is None:
+            connection = os.getenv("PANTRY_DATABASE_URL")
+            if not connection:
+                raise ValueError("PANTRY_DATABASE_URL environment variable not set")
+
         if isinstance(connection, str):
             if connection.startswith(("postgresql://", "postgres://")):
                 return _setup_postgresql_shared(connection)
@@ -48,72 +69,54 @@ def _setup_postgresql_shared(connection_string: str) -> bool:
     with psycopg2.connect(connection_string) as conn:
         with conn.cursor() as cursor:
             # Create all tables using centralized schema definitions
-            for table_name, schema in MULTI_USER_POSTGRESQL_SCHEMAS.items():
-                cursor.execute(schema)
+            for _, schema in MULTI_USER_POSTGRESQL_SCHEMAS.items():
+                _execute_with_reporting(cursor, schema)
 
             # Add household columns to existing users table if they don't exist
-            try:
-                cursor.execute(
-                    "ALTER TABLE users ADD COLUMN household_id INTEGER REFERENCES users(id)"
-                )
-            except psycopg2.errors.DuplicateColumn:
-                pass
-            except Exception:
-                pass
+            _execute_with_reporting(
+                cursor,
+                "ALTER TABLE users ADD COLUMN household_id INTEGER REFERENCES users(id)",
+                ignore_exceptions=(psycopg2.errors.DuplicateColumn,),
+            )
 
-            try:
-                cursor.execute(
-                    "ALTER TABLE users ADD COLUMN household_adults INTEGER DEFAULT 2"
-                )
-            except psycopg2.errors.DuplicateColumn:
-                pass
-            except Exception:
-                pass
+            _execute_with_reporting(
+                cursor,
+                "ALTER TABLE users ADD COLUMN household_adults INTEGER DEFAULT 2",
+                ignore_exceptions=(psycopg2.errors.DuplicateColumn,),
+            )
 
-            try:
-                cursor.execute(
-                    "ALTER TABLE users ADD COLUMN household_children INTEGER DEFAULT 0"
-                )
-            except psycopg2.errors.DuplicateColumn:
-                pass
-            except Exception:
-                pass
+            _execute_with_reporting(
+                cursor,
+                "ALTER TABLE users ADD COLUMN household_children INTEGER DEFAULT 0",
+                ignore_exceptions=(psycopg2.errors.DuplicateColumn,),
+            )
 
             # Add preferred unit columns if they don't exist
-            try:
-                cursor.execute(
-                    "ALTER TABLE users ADD COLUMN preferred_volume_unit VARCHAR(50) DEFAULT 'Milliliter'"
-                )
-            except psycopg2.errors.DuplicateColumn:
-                pass
-            except Exception:
-                pass
+            _execute_with_reporting(
+                cursor,
+                "ALTER TABLE users ADD COLUMN preferred_volume_unit VARCHAR(50) DEFAULT 'Milliliter'",
+                ignore_exceptions=(psycopg2.errors.DuplicateColumn,),
+            )
 
-            try:
-                cursor.execute(
-                    "ALTER TABLE users ADD COLUMN preferred_weight_unit VARCHAR(50) DEFAULT 'Gram'"
-                )
-            except psycopg2.errors.DuplicateColumn:
-                pass
-            except Exception:
-                pass
+            _execute_with_reporting(
+                cursor,
+                "ALTER TABLE users ADD COLUMN preferred_weight_unit VARCHAR(50) DEFAULT 'Gram'",
+                ignore_exceptions=(psycopg2.errors.DuplicateColumn,),
+            )
 
-            try:
-                cursor.execute(
-                    "ALTER TABLE users ADD COLUMN preferred_count_unit VARCHAR(50) DEFAULT 'Piece'"
-                )
-            except psycopg2.errors.DuplicateColumn:
-                pass
-            except Exception:
-                pass
+            _execute_with_reporting(
+                cursor,
+                "ALTER TABLE users ADD COLUMN preferred_count_unit VARCHAR(50) DEFAULT 'Piece'",
+                ignore_exceptions=(psycopg2.errors.DuplicateColumn,),
+            )
 
             # Create indexes for better performance
             for index_sql in MULTI_USER_POSTGRESQL_INDEXES:
-                cursor.execute(index_sql)
+                _execute_with_reporting(cursor, index_sql)
 
             # Insert default data
             for default_sql in MULTI_USER_DEFAULTS:
-                cursor.execute(default_sql)
+                _execute_with_reporting(cursor, default_sql)
 
     return True
 
@@ -125,65 +128,59 @@ def _setup_sqlite_shared(db_path: str) -> bool:
         cursor = conn.cursor()
 
         # Create all tables using centralized schema definitions
-        for table_name, schema in MULTI_USER_SQLITE_SCHEMAS.items():
-            cursor.execute(schema)
+        for _, schema in MULTI_USER_SQLITE_SCHEMAS.items():
+            _execute_with_reporting(cursor, schema)
 
         # Add household columns to existing users table if they don't exist
-        try:
-            cursor.execute(
-                "ALTER TABLE users ADD COLUMN household_id INTEGER REFERENCES users(id)"
-            )
-        except sqlite3.OperationalError:
-            pass  # Column already exists
+        _execute_with_reporting(
+            cursor,
+            "ALTER TABLE users ADD COLUMN household_id INTEGER REFERENCES users(id)",
+            ignore_exceptions=(sqlite3.OperationalError,),
+        )
 
-        try:
-            cursor.execute(
-                "ALTER TABLE users ADD COLUMN household_adults INTEGER DEFAULT 2"
-            )
-        except sqlite3.OperationalError:
-            pass  # Column already exists
+        _execute_with_reporting(
+            cursor,
+            "ALTER TABLE users ADD COLUMN household_adults INTEGER DEFAULT 2",
+            ignore_exceptions=(sqlite3.OperationalError,),
+        )
 
-        try:
-            cursor.execute(
-                "ALTER TABLE users ADD COLUMN household_children INTEGER DEFAULT 0"
-            )
-        except sqlite3.OperationalError:
-            pass  # Column already exists
+        _execute_with_reporting(
+            cursor,
+            "ALTER TABLE users ADD COLUMN household_children INTEGER DEFAULT 0",
+            ignore_exceptions=(sqlite3.OperationalError,),
+        )
 
-        try:
-            cursor.execute(
-                "ALTER TABLE users ADD COLUMN preferred_volume_unit TEXT DEFAULT 'Milliliter'"
-            )
-        except sqlite3.OperationalError:
-            pass  # Column already exists
+        _execute_with_reporting(
+            cursor,
+            "ALTER TABLE users ADD COLUMN preferred_volume_unit TEXT DEFAULT 'Milliliter'",
+            ignore_exceptions=(sqlite3.OperationalError,),
+        )
 
-        try:
-            cursor.execute(
-                "ALTER TABLE users ADD COLUMN preferred_weight_unit TEXT DEFAULT 'Gram'"
-            )
-        except sqlite3.OperationalError:
-            pass  # Column already exists
+        _execute_with_reporting(
+            cursor,
+            "ALTER TABLE users ADD COLUMN preferred_weight_unit TEXT DEFAULT 'Gram'",
+            ignore_exceptions=(sqlite3.OperationalError,),
+        )
 
-        try:
-            cursor.execute(
-                "ALTER TABLE users ADD COLUMN preferred_count_unit TEXT DEFAULT 'Piece'"
-            )
-        except sqlite3.OperationalError:
-            pass  # Column already exists
+        _execute_with_reporting(
+            cursor,
+            "ALTER TABLE users ADD COLUMN preferred_count_unit TEXT DEFAULT 'Piece'",
+            ignore_exceptions=(sqlite3.OperationalError,),
+        )
 
         # Create indexes for better performance
         for index_sql in MULTI_USER_SQLITE_INDEXES:
-            cursor.execute(index_sql)
+            _execute_with_reporting(cursor, index_sql)
 
         # Insert default data
         for default_sql in MULTI_USER_DEFAULTS:
-            cursor.execute(default_sql)
+            _execute_with_reporting(cursor, default_sql)
 
     return True
 
 
 if __name__ == "__main__":
-    # Test setup
+    # Test setup using environment variable
     print("Setting up shared database schema...")
-    success = setup_shared_database("test_shared.db")
+    success = setup_shared_database()
     print(f"Setup {'successful' if success else 'failed'}")


### PR DESCRIPTION
## Summary
- load connection string for shared database setup from `PANTRY_DATABASE_URL`
- log SQL statements that fail during shared database setup for easier troubleshooting

## Testing
- `pip install psycopg2-binary` *(fails: Could not find a version that satisfies the requirement psycopg2-binary (403 Forbidden))*
- `pytest` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_689905f9bce48330949057c43bf2e349